### PR TITLE
V.1.10/feature/buorivc-19 removed text hint blocks

### DIFF
--- a/src/addons/mod/choice/components/index/addon-mod-choice-index.html
+++ b/src/addons/mod/choice/components/index/addon-mod-choice-index.html
@@ -71,13 +71,6 @@
         </ion-item>
     </ion-card>
 
-    <!-- Inform what will happen with the choices. -->
-    <ion-card class="core-info-card" *ngIf="canEdit && publishInfo && options.length">
-        <ion-item>
-            <ion-icon name="fas-info-circle" slot="start" aria-hidden="true"></ion-icon>
-            <ion-label>{{ publishInfo | translate }}</ion-label>
-        </ion-item>
-    </ion-card>
 
     <!-- Choice options -->
     <ion-card *ngIf="options.length && choice">
@@ -155,13 +148,6 @@
             </ion-row>
         </ion-grid>
     </div>
-
-    <ion-card class="core-info-card" *ngIf="!canSeeResults && !choiceNotOpenYet">
-        <ion-item>
-            <ion-icon name="fas-info-circle" slot="start" aria-hidden="true"></ion-icon>
-            <ion-label><p>{{ 'addon.mod_choice.noresultsviewable' | translate }}</p></ion-label>
-        </ion-item>
-    </ion-card>
 </core-loading>
 
 <!-- Template to render a choice option label. -->


### PR DESCRIPTION
<img width="350" alt="image" src="https://user-images.githubusercontent.com/44264209/196656700-297a147c-1cfa-47c0-ab70-8b045020797b.png">
